### PR TITLE
Use process.runtimeconfig.json to Set Runtime in CLRImports Module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,3 +22,9 @@ jobs:
 
       - name: Run Tests
         run: dotnet test ./tests/bin/Release/net6.0/Tests.dll
+
+      - name: BuildDataProcessing
+        run: dotnet build ./DataProcessing/DataProcessing.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1
+
+      - name: Test File Creation
+        run: ls ./DataProcessing/bin/Release/net6.0/process.runtimeconfig.json

--- a/DataProcessing/CLRImports.py
+++ b/DataProcessing/CLRImports.py
@@ -1,24 +1,11 @@
 # This file is used to import the environment and classes/methods of LEAN.
 # so that any python file could be using LEAN's classes/methods.
-
-from os import remove
-from json import dump
 from clr_loader import get_coreclr
 from pythonnet import set_runtime
 
-with open('tmp.json', 'w') as fp:
-    dump({
-            "runtimeOptions": {
-                "tfm": "net5.0",
-                "framework": {
-                    "name": "Microsoft.NETCore.App",
-                    "version": "5.0.0"
-                 }
-             }
-         },
-        fp, ensure_ascii=True, indent=4)
-set_runtime(get_coreclr('tmp.json'))
-remove('tmp.json')
+# process.runtimeconfig.json is created when we build the DataProcessing Project:
+# dotnet build .\DataProcessing\DataProcessing.csproj
+set_runtime(get_coreclr('process.runtimeconfig.json'))
 
 from AlgorithmImports import *
 from QuantConnect.Lean.Engine.DataFeeds import *

--- a/DataProcessing/DataProcessing.csproj
+++ b/DataProcessing/DataProcessing.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
+        <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
         <AssemblyName>process</AssemblyName>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/DataProcessing/Program.cs
+++ b/DataProcessing/Program.cs
@@ -1,0 +1,35 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+
+namespace QuantConnect.DataProcessing
+{
+    /// <summary>
+    /// Entrypoint for the data downloader/converter
+    /// </summary>
+    public class Program
+    {
+        /// <summary>
+        /// Entrypoint of the program
+        /// </summary>
+        /// <returns>Exit code. 0 equals successful, and any other value indicates the downloader/converter failed.</returns>
+        public static void Main()
+        {
+            // The downloader/converter was successful
+            Environment.Exit(0);
+        }
+    }
+}


### PR DESCRIPTION
Adds dummy `Program.cs` to create `process.runtimeconfig.json` that will be used by `CLRImports` module that was updated according to the latest SDK version.