### PR TITLE
Use process.runtimeconfig.json Absolute Path to Set Runtime in CLRImports Module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,5 +26,7 @@ jobs:
       - name: BuildDataProcessing
         run: dotnet build ./DataProcessing/DataProcessing.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1
 
-      - name: Test File Creation
-        run: ls ./DataProcessing/bin/Release/net6.0/process.runtimeconfig.json
+      - name: Test CLRImports Script
+        run: |-
+            pip install clr_loader
+            python ./DataProcessing/bin/Release/net6.0/CLRImports.py

--- a/DataProcessing/CLRImports.py
+++ b/DataProcessing/CLRImports.py
@@ -1,11 +1,12 @@
 # This file is used to import the environment and classes/methods of LEAN.
 # so that any python file could be using LEAN's classes/methods.
+from os.path import join, dirname, realpath
 from clr_loader import get_coreclr
 from pythonnet import set_runtime
 
 # process.runtimeconfig.json is created when we build the DataProcessing Project:
 # dotnet build .\DataProcessing\DataProcessing.csproj
-set_runtime(get_coreclr('process.runtimeconfig.json'))
+set_runtime(get_coreclr(join(dirname(realpath(__file__)), "process.runtimeconfig.json")))
 
 from AlgorithmImports import *
 from QuantConnect.Lean.Engine.DataFeeds import *


### PR DESCRIPTION
Update CI Test to run `CLRImports` from the root directory.