### PR TITLE
Fixes Universe Selection to Handle Null Values

### DIFF
--- a/BrainCompanyFilingLanguageMetricsUniverse.cs
+++ b/BrainCompanyFilingLanguageMetricsUniverse.cs
@@ -107,7 +107,7 @@ namespace QuantConnect.DataSource
 
             data.Symbol = new Symbol(SecurityIdentifier.Parse(csv[0]), csv[1]);
             data.Time = date - Period;
-            data.Value = !string.IsNullOrWhiteSpace(csv[4]) ? decimal.Parse(csv[4], NumberStyles.Any, CultureInfo.InvariantCulture) : 0m;
+            data.Value = csv[4].IfNotNullOrEmpty(0m, s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture));
 
             return data;
         }

--- a/BrainSentimentIndicatorUniverse.cs
+++ b/BrainSentimentIndicatorUniverse.cs
@@ -121,7 +121,7 @@ namespace QuantConnect.DataSource
         public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode)
         {
             var csv = line.Split(',');
-            var sentiment7Days = decimal.Parse(csv[4], NumberStyles.Any, CultureInfo.InvariantCulture);
+            var sentiment7Days = csv[4].IfNotNullOrEmpty<decimal?>(s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture));
 
             return new BrainSentimentIndicatorUniverse
             {
@@ -139,7 +139,7 @@ namespace QuantConnect.DataSource
 
                 Symbol = new Symbol(SecurityIdentifier.Parse(csv[0]), csv[1]),
                 Time = date - Period,
-                Value = sentiment7Days
+                Value = sentiment7Days ?? 0m
             };
         }
 

--- a/BrainStockRankingUniverse.cs
+++ b/BrainStockRankingUniverse.cs
@@ -108,7 +108,7 @@ namespace QuantConnect.DataSource
 
                 Symbol = new Symbol(SecurityIdentifier.Parse(csv[0]), csv[1]),
                 Time = date - Period,
-                Value = (decimal)rank2Days
+                Value = rank2Days ?? 0m
             };
         }
 

--- a/tests/BrainSentimentIndicatorUniverseTests.cs
+++ b/tests/BrainSentimentIndicatorUniverseTests.cs
@@ -52,6 +52,33 @@ namespace QuantConnect.DataLibrary.Tests
         }
 
         [Test]
+        public void ReaderNullSentiment7DaysTest()
+        {
+            var factory = new BrainSentimentIndicatorUniverse();
+            var line = "CNCE VO2R14MRA2XX,CNCE,,,,,,22,14,0.323100,-0.945800,-0.745700";
+
+            var date = new DateTime(2022, 04, 21);
+            var data = (BrainSentimentIndicatorUniverse)factory.Reader(null, line, date, false);
+            Assert.AreEqual(Time.OneDay, data.Period);
+            Assert.AreEqual(date, data.EndTime);
+            Assert.AreEqual("CNCE", data.Symbol.Value);
+
+            // Value is 0 because 7-day Sentiment is null
+            Assert.AreEqual(0, data.Value);
+            Assert.IsNull(data.Sentiment7Days);
+            Assert.IsNull(data.SentimentalArticleMentions7Days);
+            Assert.IsNull(data.SentimentalBuzzVolume7Days);
+            Assert.IsNull(data.TotalArticleMentions7Days);
+            Assert.IsNull(data.TotalBuzzVolume7Days);
+
+            Assert.AreEqual(22, data.TotalArticleMentions30Days);
+            Assert.AreEqual(14, data.SentimentalArticleMentions30Days);
+            Assert.AreEqual(0.323100, data.Sentiment30Days);
+            Assert.AreEqual(-0.945800, data.TotalBuzzVolume30Days);
+            Assert.AreEqual(-0.745700, data.SentimentalBuzzVolume30Days);
+        }
+
+        [Test]
         public void JsonRoundTrip()
         {
             var expected = CreateNewInstance();


### PR DESCRIPTION
In some dates, we have Sentiment Indicators for 30 days but not 7 days. In the current implementation we took for granted that if we have 30 days, we should also have 7 days.