### PR TITLE
Rename BrainStockRanking30Day to BrainStockRanking21Day

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,5 +28,5 @@ jobs:
 
       - name: Test CLRImports Script
         run: |-
-            pip install clr_loader
+            pip install --no-cache-dir clr-loader==0.1.6
             python ./DataProcessing/bin/Release/net6.0/CLRImports.py

--- a/BrainStockRanking21Day.cs
+++ b/BrainStockRanking21Day.cs
@@ -19,13 +19,13 @@ namespace QuantConnect.DataSource
     /// <summary>
     /// Brain universe stock rankings on expected returns in the next 30 days
     /// </summary>
-    public class BrainStockRanking30Day : BrainStockRankingBase<BrainStockRanking30Day>
+    public class BrainStockRanking21Day : BrainStockRankingBase<BrainStockRanking21Day>
     {
         /// <summary>
         /// Data source ID
         /// </summary>
         public static int DataSourceId { get; } = 2029;
 
-        protected override int LookbackDays { get; set; } = 30;
+        protected override int LookbackDays { get; set; } = 21;
     }
 }

--- a/tests/BrainDataTests.cs
+++ b/tests/BrainDataTests.cs
@@ -100,7 +100,7 @@ namespace QuantConnect.DataLibrary.Tests
 
         private BaseData CreateNewInstance()
         {
-            return new BrainStockRanking30Day
+            return new BrainStockRanking21Day
             {
                 Symbol = Symbol.Empty,
                 Time = DateTime.Today,


### PR DESCRIPTION
There is no data for 30-day ranking.
Available lookback: 2, 3, 5, 10, and 21.