### PR TITLE
Expose filing language metric similarity in universe selection

### DIFF
--- a/BrainCompanyFilingLanguageMetricsUniverse.cs
+++ b/BrainCompanyFilingLanguageMetricsUniverse.cs
@@ -100,9 +100,9 @@ namespace QuantConnect.DataSource
 
             var data = (BrainCompanyFilingLanguageMetricsUniverse<T>)((object)new T());
 
-            data.ReportSentiment = BrainCompanyFilingLanguageMetrics.Parse(csv.Skip(2).Take(11).ToList());
-            data.RiskFactorsStatementSentiment = BrainCompanyFilingLanguageMetrics.Parse(csv.Skip(13).Take(11).ToList());
-            data.ManagementDiscussionAnalyasisOfFinancialConditionAndResultsOfOperations = BrainCompanyFilingLanguageMetrics.Parse(csv.Skip(24).Take(11).ToList());
+            data.ReportSentiment = BrainCompanyFilingLanguageMetrics.Parse(csv.Skip(2).Take(11).ToList(), csv.Skip(39).Take(7).ToList());
+            data.RiskFactorsStatementSentiment = BrainCompanyFilingLanguageMetrics.Parse(csv.Skip(13).Take(11).ToList(), csv.Skip(46).Take(3).ToList());
+            data.ManagementDiscussionAnalyasisOfFinancialConditionAndResultsOfOperations = BrainCompanyFilingLanguageMetrics.Parse(csv.Skip(24).Take(11).ToList(), csv.Skip(49).ToList());
 
             data.Symbol = new Symbol(SecurityIdentifier.Parse(csv[0]), csv[1]);
             // We need to convert the time since the date is in UTC, and AddUniverse sets the ExchangeTimeZone to TimeZones.NewYork

--- a/DataProcessing/universe.py
+++ b/DataProcessing/universe.py
@@ -89,6 +89,6 @@ class UniverseDataProcessing:
                         days = file.split(os.sep)[-3]
                         data[date][ticker][days] = ",".join(datum[1:]).replace("\n", "")
                     else:
-                        data[date][ticker] = ",".join(datum[3:36]).replace("\n", "")
+                        data[date][ticker] = ",".join(datum[3:53]).replace("\n", "")
 
         return data, universe_path


### PR DESCRIPTION
## Description

Expose the filing language metric similarity values (`Similarity.All` and the related fields) in `BrainCompanyFilingLanguageMetrics` universe selection (`BrainCompanyFilingLanguageMetricsUniverseAll` and `Universe10K`). They were already available point in time via `add_data` but were missing from universe selection.

## Related Issue

Resolves #32

## Motivation and Context

`BrainCompanyFilingLanguageMetrics.Parse` only attaches `Similarity` when given its second argument. On the universe path the similarity columns were never written to the universe file (`universe.py` kept only `datum[3:36]`) and the universe `Reader` used the metrics only `Parse` overload, so `Similarity` was always null. The fix writes the trailing similarity columns and parses them in the universe `Reader` with the same offsets as `BrainCompanyFilingLanguageMetricsBase.Reader` (`Skip(39).Take(7)`, `Skip(46).Take(3)`, `Skip(49)`), bringing universe selection in line with the point in time type. The universe file schema gains columns, so deployed universe data needs reprocessing.

## Requires Documentation Change

N/A

## How Has This Been Tested?

`dotnet test` passes (24 of 24). Verified that the universe column offsets line up with the point in time reader, so `SIMILARITY_ALL` maps to `Similarity.All` for the report, risk factor, and management discussion sections.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention bug-&lt;issue#&gt;-&lt;description&gt; or feature-&lt;issue#&gt;-&lt;description&gt;
